### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-fluent-plugin-yammer
+fluent-plugin-yammer, a plugin for [Fluentd](http://fluentd.org)
 =============
 
 [![Gem Version](https://badge.fury.io/rb/fluent-plugin-yammer.png)](http://badge.fury.io/rb/fluent-plugin-yammer)


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
