### PR TITLE
Support log level per plugin

### DIFF
--- a/lib/fluent/plugin/out_yammer.rb
+++ b/lib/fluent/plugin/out_yammer.rb
@@ -27,6 +27,6 @@ class Fluent::YammerOutput < Fluent::Output
   def create_message(message)
     @yammer.create_message(message, :group_id => @group_id)
   rescue Yammer::Error => e
-    $log.error("Yammer Error: #{e.message}")
+    log.error("Yammer Error: #{e.message}")
   end
 end


### PR DESCRIPTION
This change will drop Fluentd v0.10.x support.
But it's no problem because Fluentd v0.10.x has already reached EOL.